### PR TITLE
WIP: feat: implement error codes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,15 +15,15 @@ RUN go get -u -v github.com/golang/protobuf/protoc-gen-go \
 	github.com/go-chi/chi \
 	github.com/renstrom/fuzzysearch/fuzzy
 
-RUN mkdir -p /go/src/github.com/jekiapp/gripmock
+RUN mkdir -p /go/src/github.com/charandas/gripmock
 
-COPY . /go/src/github.com/jekiapp/gripmock
+COPY . /go/src/github.com/charandas/gripmock
 
-WORKDIR /go/src/github.com/jekiapp/gripmock
+WORKDIR /go/src/github.com/charandas/gripmock
 
 RUN go build
 
-RUN mv /go/src/github.com/jekiapp/gripmock/gripmock /usr/bin/gripmock
+RUN mv /go/src/github.com/charandas/gripmock/gripmock /usr/bin/gripmock
 
 RUN rm -rf *
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ RUN mkdir /proto
 
 RUN mkdir /stubs
 
-RUN apk -U --no-cache add git protobuf
+RUN apk -U --no-cache add git protobuf-dev
 
 RUN go get -u -v github.com/golang/protobuf/protoc-gen-go \
 	github.com/mitchellh/mapstructure \

--- a/Readme.md
+++ b/Readme.md
@@ -13,7 +13,7 @@ Matched stub will be returned to GRPC service then further parse it to response 
 
 ## Quick Usage
 First, prepare your `.proto` file. or you can use `hello.proto` in `example/pb/` folder. Suppose you put it in `/mypath/hello.proto`. We gonna use Docker image for easier example test.
-basic syntax to run GripMock is 
+basic syntax to run GripMock is
 `gripmock <protofile>`
 
 - Install [Docker](https://docs.docker.com/install/)
@@ -44,7 +44,11 @@ Stub Format is JSON text format. It has skeleton like below:
     "data":{
       // put result fields here
     },
-    "error":"<error message>" // Optional. if you want to return error instead.
+    "error": "string", // Optional. if you want to return error instead. Would be thrown as grpc UNKNOWN status
+    "errorObject": { // Optional. if you want to return error instead.
+      "code": "<integer>", // https://github.com/grpc/grpc-go/blob/master/codes/codes.go
+      "message": "<error message>"
+    }
   }
 }
 ```

--- a/generator.go
+++ b/generator.go
@@ -30,9 +30,78 @@ type ProtobufGolangReference struct {
 
 // This should contain all protobuf references that we want to support, with at least the well known types
 var referenceTypeRegistry = map[string]ProtobufGolangReference{
+	// General use Well Known Types
+	"google.protobuf.Any": {
+		GolangImport:    "github.com/golang/protobuf/ptypes/any",
+		GolangReference: "any.Any",
+	},
+	"google.protobuf.Duration": {
+		GolangImport:    "github.com/golang/protobuf/ptypes/duration",
+		GolangReference: "duration.Duration",
+	},
 	"google.protobuf.Empty": {
 		GolangImport:    "github.com/golang/protobuf/ptypes/empty",
 		GolangReference: "empty.Empty",
+	},
+	"google.protobuf.Timestamp": {
+		GolangImport:    "github.com/golang/protobuf/ptypes/timestamp",
+		GolangReference: "timestamp.Timestamp",
+	},
+
+	// Basic Value Wrapper Well Known Types
+	"google.protobuf.BoolValue": {
+		GolangImport:    "github.com/golang/protobuf/ptypes/wrappers",
+		GolangReference: "wrappers.BoolValue",
+	},
+	"google.protobuf.BytesValue": {
+		GolangImport:    "github.com/golang/protobuf/ptypes/wrappers",
+		GolangReference: "wrappers.BytesValue",
+	},
+	"google.protobuf.DoubleValue": {
+		GolangImport:    "github.com/golang/protobuf/ptypes/wrappers",
+		GolangReference: "wrappers.DoubleValue",
+	},
+	"google.protobuf.FloatValue": {
+		GolangImport:    "github.com/golang/protobuf/ptypes/wrappers",
+		GolangReference: "wrappers.FloatValue",
+	},
+	"google.protobuf.Int32Value": {
+		GolangImport:    "github.com/golang/protobuf/ptypes/wrappers",
+		GolangReference: "wrappers.Int32Value",
+	},
+	"google.protobuf.Int64Value": {
+		GolangImport:    "github.com/golang/protobuf/ptypes/wrappers",
+		GolangReference: "wrappers.Int64Value",
+	},
+	"google.protobuf.StringValue": {
+		GolangImport:    "github.com/golang/protobuf/ptypes/wrappers",
+		GolangReference: "wrappers.StringValue",
+	},
+	"google.protobuf.UInt32Value": {
+		GolangImport:    "github.com/golang/protobuf/ptypes/wrappers",
+		GolangReference: "wrappers.UInt32Value",
+	},
+	"google.protobuf.UInt64Value": {
+		GolangImport:    "github.com/golang/protobuf/ptypes/wrappers",
+		GolangReference: "wrappers.UInt64Value",
+	},
+
+	// Special Value Wrapper Well Known Types
+	"google.protobuf.ListValue": {
+		GolangImport:    "github.com/golang/protobuf/ptypes/struct",
+		GolangReference: "struct.ListValue",
+	},
+	"google.protobuf.NullValue": {
+		GolangImport:    "github.com/golang/protobuf/ptypes/struct",
+		GolangReference: "struct.NullValue",
+	},
+	"google.protobuf.Struct": {
+		GolangImport:    "github.com/golang/protobuf/ptypes/struct",
+		GolangReference: "struct.Struct",
+	},
+	"google.protobuf.Value": {
+		GolangImport:    "github.com/golang/protobuf/ptypes/struct",
+		GolangReference: "struct.Value",
 	},
 }
 

--- a/gripmock.go
+++ b/gripmock.go
@@ -11,7 +11,7 @@ import (
 	"strings"
 	"syscall"
 
-	"github.com/jekiapp/gripmock/stub"
+	"github.com/charandas/gripmock/stub"
 )
 
 func main() {

--- a/gripmock.go
+++ b/gripmock.go
@@ -115,7 +115,6 @@ func generateProtoc(protoPath []string, output string) {
 	args := []string{"-I", protodir, "-I", "/usr/include"}
 	args = append(args, protoPath...)
 	args = append(args, "--go_out=plugins=grpc:"+output)
-	fmt.Printf("protoc %v", args)
 	protoc := exec.Command("protoc", args...)
 	protoc.Stdout = os.Stdout
 	protoc.Stderr = os.Stderr

--- a/gripmock.go
+++ b/gripmock.go
@@ -112,9 +112,10 @@ func generateProtoc(protoPath []string, output string) {
 		protodir = strings.Join(protodirs[:len(protodirs)-1], "/") + "/"
 	}
 
-	args := []string{"-I", protodir}
+	args := []string{"-I", protodir, "-I", "/usr/include"}
 	args = append(args, protoPath...)
 	args = append(args, "--go_out=plugins=grpc:"+output)
+	fmt.Printf("protoc %v", args)
 	protoc := exec.Command("protoc", args...)
 	protoc.Stdout = os.Stdout
 	protoc.Stderr = os.Stderr

--- a/proto_parser.go
+++ b/proto_parser.go
@@ -15,8 +15,8 @@ type Service struct {
 
 type Method struct {
 	Name   string `"rpc" @Ident `
-	Input  string `"(" @Ident ")"`
-	Output string `"returns" "(" "stream"? @Ident ")"`
+	Input  string `"(" @(Ident{ "." Ident }) ")"`
+	Output string `"returns" "(" "stream"? @(Ident{ "." Ident }) ")"`
 	// TODO deal with body of method
 	Closing string `"{"?"}"? ";"?`
 }

--- a/stub/storage.go
+++ b/stub/storage.go
@@ -178,7 +178,15 @@ func matches(expect, actual map[string]interface{}) bool {
 	for keyExpect, valueExpect := range expect {
 		valueExpectString, ok := valueExpect.(string)
 		if !ok {
-			return false
+			valueExpectMap, okMap := valueExpect.(map[string]interface{})
+			if !okMap {
+				return false
+			}
+			valueActualMap, okMap := actual[keyExpect].(map[string]interface{})
+			if !okMap {
+				return false
+			}
+			return matches(valueExpectMap, valueActualMap)
 		}
 		actualvalue, ok := actual[keyExpect].(string)
 		if !ok {
@@ -187,7 +195,7 @@ func matches(expect, actual map[string]interface{}) bool {
 
 		match, err := regexp.Match(valueExpectString, []byte(actualvalue))
 		if err != nil {
-			log.Println("Error on matching regex %s with %s error:%v", valueExpectString, actualvalue, err)
+			log.Printf("Error on matching regex %s with %s error: %v\n", valueExpectString, actualvalue, err)
 		}
 
 		if !match {

--- a/stub/storage.go
+++ b/stub/storage.go
@@ -168,6 +168,11 @@ func contains(expect, actual map[string]interface{}) bool {
 		}
 
 		if !reflect.DeepEqual(val, actualvalue) {
+			valueExpectMap, okExpectMap := val.(map[string]interface{})
+			valueActualMap, okActualMap := actual[key].(map[string]interface{})
+			if okExpectMap && okActualMap {
+				return contains(valueExpectMap, valueActualMap)
+			}
 			return false
 		}
 	}

--- a/stub/stub.go
+++ b/stub/stub.go
@@ -66,9 +66,9 @@ type Input struct {
 }
 
 type Output struct {
-	Data  map[string]interface{} `json:"data"`
-	ErrorObject GrpcError        `json:"errorObject"`
-	Error string                 `json:string`
+	Data        map[string]interface{} `json:"data"`
+	ErrorObject GrpcError              `json:"errorObject"`
+	Error       string                 `json:string`
 }
 
 func addStub(w http.ResponseWriter, r *http.Request) {

--- a/stub/stub_test.go
+++ b/stub/stub_test.go
@@ -48,7 +48,7 @@ func TestStub(t *testing.T) {
 				return httptest.NewRequest("GET", "/", nil)
 			},
 			handler: listStub,
-			expect:  "{\"Testing\":{\"TestMethod\":[{\"Input\":{\"equals\":{\"Hola\":\"Mundo\"},\"contains\":null,\"matches\":null},\"Output\":{\"data\":{\"Hello\":\"World\"},\"error\":\"\"}}]}}\n",
+			expect:  "{\"Testing\":{\"TestMethod\":[{\"Input\":{\"equals\":{\"Hola\":\"Mundo\"},\"contains\":null,\"matches\":null},\"Output\":{\"data\":{\"Hello\":\"World\"},\"errorObject\":{\"message\":\"\",\"code\":0},\"Error\":\"\"}}]}}\n",
 		},
 		{
 			name: "find stub equals",
@@ -57,7 +57,7 @@ func TestStub(t *testing.T) {
 				return httptest.NewRequest("POST", "/find", bytes.NewReader([]byte(payload)))
 			},
 			handler: handleFindStub,
-			expect:  "{\"data\":{\"Hello\":\"World\"},\"error\":\"\"}\n",
+			expect:  "{\"data\":{\"Hello\":\"World\"},\"errorObject\":{\"message\":\"\",\"code\":0},\"Error\":\"\"}\n",
 		},
 		{
 			name: "add stub contains",
@@ -97,7 +97,7 @@ func TestStub(t *testing.T) {
 				return httptest.NewRequest("GET", "/find", bytes.NewReader([]byte(payload)))
 			},
 			handler: handleFindStub,
-			expect:  "{\"data\":{\"hello\":\"world\"},\"error\":\"\"}\n",
+			expect:  "{\"data\":{\"hello\":\"world\"},\"errorObject\":{\"message\":\"\",\"code\":0},\"Error\":\"\"}\n",
 		}, {
 			name: "add stub matches regex",
 			mock: func() *http.Request {
@@ -132,7 +132,46 @@ func TestStub(t *testing.T) {
 				return httptest.NewRequest("GET", "/find", bytes.NewReader([]byte(payload)))
 			},
 			handler: handleFindStub,
-			expect:  "{\"data\":{\"reply\":\"OK\"},\"error\":\"\"}\n",
+			expect:  "{\"data\":{\"reply\":\"OK\"},\"errorObject\":{\"message\":\"\",\"code\":0},\"Error\":\"\"}\n",
+		}, {
+			name: "add stub nested matches regex",
+			mock: func() *http.Request {
+				payload := `{
+						"service":"Testing2",
+						"method":"TestMethod",
+						"input":{
+							"matches":{
+								"field1": {
+									"nested1": ".*ello$"
+								}
+							}
+						},
+						"output":{
+							"data":{
+								"reply":"OK"
+							}
+						}
+					}`
+				return httptest.NewRequest("POST", "/add", bytes.NewReader([]byte(payload)))
+			},
+			handler: addStub,
+			expect:  "Success add stub",
+		}, {
+			name: "find stub nested matches regex",
+			mock: func() *http.Request {
+				payload := `{
+						"service":"Testing2",
+						"method":"TestMethod",
+						"data":{
+							"field1": {
+								"nested1": "hello"
+							}
+						}
+					}`
+				return httptest.NewRequest("GET", "/find", bytes.NewReader([]byte(payload)))
+			},
+			handler: handleFindStub,
+			expect:  "{\"data\":{\"reply\":\"OK\"},\"errorObject\":{\"message\":\"\",\"code\":0},\"Error\":\"\"}\n",
 		}, {
 			name: "error find stub contains",
 			mock: func() *http.Request {

--- a/stub/stub_test.go
+++ b/stub/stub_test.go
@@ -98,7 +98,55 @@ func TestStub(t *testing.T) {
 			},
 			handler: handleFindStub,
 			expect:  "{\"data\":{\"hello\":\"world\"},\"errorObject\":{\"message\":\"\",\"code\":0},\"Error\":\"\"}\n",
-		}, {
+		},
+		{
+			name: "add stub nested contains",
+			mock: func() *http.Request {
+				payload := `{
+								"service": "Testing",
+								"method":"TestMethod",
+								"input":{
+									"contains":{
+										"field1":"hello field1",
+										"field3": {
+											"nested1": "hello nested1",
+											"nested2": "hello nested2"
+										}
+									}
+								},
+								"output":{
+									"data":{
+										"hello":"world"
+									}
+								}
+							}`
+				return httptest.NewRequest("POST", "/add", bytes.NewReader([]byte(payload)))
+			},
+			handler: addStub,
+			expect:  `Success add stub`,
+		},
+		{
+			name: "find stub nested contains",
+			mock: func() *http.Request {
+				payload := `{
+						"service":"Testing",
+						"method":"TestMethod",
+						"data":{
+							"field1":"hello field1",
+							"field2":"hello field2",
+							"field3": {
+								"nested1": "hello nested1",
+								"nested2": "hello nested2",
+								"nested3": "hello nested3"
+							}
+						}
+					}`
+				return httptest.NewRequest("GET", "/find", bytes.NewReader([]byte(payload)))
+			},
+			handler: handleFindStub,
+			expect:  "{\"data\":{\"hello\":\"world\"},\"errorObject\":{\"message\":\"\",\"code\":0},\"Error\":\"\"}\n",
+		},
+		{
 			name: "add stub matches regex",
 			mock: func() *http.Request {
 				payload := `{
@@ -119,7 +167,8 @@ func TestStub(t *testing.T) {
 			},
 			handler: addStub,
 			expect:  "Success add stub",
-		}, {
+		},
+		{
 			name: "find stub matches regex",
 			mock: func() *http.Request {
 				payload := `{
@@ -133,7 +182,8 @@ func TestStub(t *testing.T) {
 			},
 			handler: handleFindStub,
 			expect:  "{\"data\":{\"reply\":\"OK\"},\"errorObject\":{\"message\":\"\",\"code\":0},\"Error\":\"\"}\n",
-		}, {
+		},
+		{
 			name: "add stub nested matches regex",
 			mock: func() *http.Request {
 				payload := `{
@@ -156,7 +206,8 @@ func TestStub(t *testing.T) {
 			},
 			handler: addStub,
 			expect:  "Success add stub",
-		}, {
+		},
+		{
 			name: "find stub nested matches regex",
 			mock: func() *http.Request {
 				payload := `{
@@ -172,7 +223,8 @@ func TestStub(t *testing.T) {
 			},
 			handler: handleFindStub,
 			expect:  "{\"data\":{\"reply\":\"OK\"},\"errorObject\":{\"message\":\"\",\"code\":0},\"Error\":\"\"}\n",
-		}, {
+		},
+		{
 			name: "error find stub contains",
 			mock: func() *http.Request {
 				payload := `{
@@ -188,7 +240,8 @@ func TestStub(t *testing.T) {
 			},
 			handler: handleFindStub,
 			expect:  "Can't find stub \n\nService: Testing \n\nMethod: TestMethod \n\nInput\n\n{\n\tfield1: hello field1\n\tfield2: hello field2\n\tfield3: hello field4\n}\n\nClosest Match \n\ncontains:{\n\tfield1: hello field1\n\tfield3: hello field3\n}",
-		}, {
+		},
+		{
 			name: "error find stub equals",
 			mock: func() *http.Request {
 				payload := `{"service":"Testing","method":"TestMethod","data":{"Hola":"Dunia"}}`


### PR DESCRIPTION
I noticed that the error codes as strings would not allow a user to create actual grpc error statuses.

Accordingly, I added this functionality, so that stubs can now be specifying it as this:

```javascript
{
  "output": {
    "error": "Invalid phone number", // still support old way
    "errorObject": { // new way
      "message": "Invalid phone number",
      "code": 3 // corresponds to gRPC status for INVALID_ARGUMENT
  }
}
```

Need to add the following:

- [ ] updated tests
- [x] backwards compatibility so users using `error` as string don't suddenly have broken stubs