### PR TITLE
Readme typo

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -20,7 +20,7 @@ basic syntax to run GripMock is
 - Run `docker pull ahmadmuzakki/gripmock` to pull the image
 - We gonna mount `/mypath/hello.proto` (it must a fullpath) into container and also we expose ports needed. Run `docker run -p 4770:4770 -p 4771:4771 -v /mypath:/proto ahmadmuzakki/gripmock gripmock /proto/hello.proto`
 - On separate terminal we gonna add stub into stub service. Run `curl -X POST -d '{"service":"Greeter","method":"SayHello","input":{"equals":{"name":"gripmock"}},"output":{"data":{"message":"Hello GripMock"}}}' localhost:4771/add `
-- Now we are ready to test it with our client. you can find client example file under `example/client/`. Execute one of your preferred language. Example for go: `go run example/client/go/main.go`
+- Now we are ready to test it with our client. you can find client example file under `example/client/`. Execute one of your preferred language. Example for go: `go run example/client/go/*.go`
 
 ## Stubbing
 

--- a/Readme.md
+++ b/Readme.md
@@ -31,6 +31,7 @@ Stub Server running on `http://localhost:4771`
 - `GET /` Will list all stubs mapping.
 - `POST /add` Will add stub with provided stub data
 - `POST /find` Find matching stub with provided input. see [Input Matching](#input_matching) below.
+- `GET /clear` Clear stub mappings.
 
 Stub Format is JSON text format. It has skeleton like below:
 ```


### PR DESCRIPTION
From:
```
go run example/client/go/main.go
# command-line-arguments
example/client/go/main.go:18:7: undefined: NewGreeterClient
example/client/go/main.go:25:46: undefined: HelloRequest
```
To
```
go run example/client/go/*.go
2019/08/08 12:44:05 Greeting: Hello GripMock
```