### PR TITLE
[Bug] empty go package

### DIFF
--- a/protoc-gen-gripmock/generator.go
+++ b/protoc-gen-gripmock/generator.go
@@ -161,10 +161,14 @@ func resolveDependencies(protos []*descriptor.FileDescriptorProto) map[string]st
 	aliasNum := 1
 	for _, dep := range depsFile {
 		for _, proto := range protos {
-			if proto.GetName() != dep {
+			pkg := proto.GetOptions().GetGoPackage()
+
+			// skip whether its not intended deps
+			// or has empty Go package
+			if proto.GetName() != dep || pkg == "" {
 				continue
 			}
-			pkg := proto.GetOptions().GetGoPackage()
+
 			alias := getAlias(proto.GetName())
 			// in case of found same alias
 			if ok := aliases[alias]; ok {


### PR DESCRIPTION
bugfix when the dependency is the same package and not specifying go_package. currently gripmock support multi proto files with the same package, we're not yet support dependecies across pacakge.