### PR TITLE
Support common google apis and fix issue with ";" in package names

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,7 @@ RUN mkdir /stubs
 RUN apk -U --no-cache add git protobuf
 
 RUN go get -u -v github.com/golang/protobuf/protoc-gen-go \
+    github.com/grpc-ecosystem/grpc-gateway/protoc-gen-grpc-gateway \
 	github.com/mitchellh/mapstructure \
 	google.golang.org/grpc \
 	google.golang.org/grpc/reflection \

--- a/gripmock.go
+++ b/gripmock.go
@@ -102,10 +102,13 @@ func generateProtoc(param protocParam) {
 	if len(protodirs) > 0 {
 		protodir = strings.Join(protodirs[:len(protodirs)-1], "/") + "/"
 	}
-
 	args := []string{"-I", protodir}
 	// include well-known-types
 	args = append(args, "-I", "/protobuf")
+	if os.Getenv("GOPATH") != "" {
+		googlesApisPath := os.Getenv("GOPATH")+"/src/github.com/grpc-ecosystem/grpc-gateway/third_party/googleapis/"
+		args = append(args, "-I", googlesApisPath)
+	}
 	args = append(args, param.protoPath...)
 	args = append(args, "--go_out=plugins=grpc:"+param.output)
 	args = append(args, fmt.Sprintf("--gripmock_out=admin-port=%s,grpc-address=%s,grpc-port=%s:%s",

--- a/protoc-gen-gripmock/generator.go
+++ b/protoc-gen-gripmock/generator.go
@@ -170,8 +170,11 @@ func resolveDependencies(protos []*descriptor.FileDescriptorProto) map[string]st
 			}
 
 			// some package declarations use a semicolon, which causes a formatting error
-			// ignore for now
-			pkg = strings.Split(pkg, ";")[0]
+			// use the alias instead, if available
+			var sections = strings.Split(pkg, ";")
+			if len(sections) > 1 {
+				pkg = sections[1]
+			}
 
 			alias := getAlias(proto.GetName())
 			// in case of found same alias

--- a/protoc-gen-gripmock/generator.go
+++ b/protoc-gen-gripmock/generator.go
@@ -169,6 +169,10 @@ func resolveDependencies(protos []*descriptor.FileDescriptorProto) map[string]st
 				continue
 			}
 
+			// some package declarations use a semicolon, which causes a formatting error
+			// ignore for now
+			pkg = strings.Split(pkg, ";")[0]
+
 			alias := getAlias(proto.GetName())
 			// in case of found same alias
 			if ok := aliases[alias]; ok {


### PR DESCRIPTION
I noticed that if you try to start a service with a proto file that includes a dependency on something with package like `go_package=github.com/golang/protobuf/protoc-gen-go/descriptor;descriptor`, it fails with:

```
2019/09/05 03:16:17 Failed to generate server formatting 20:19: invalid import path: "github.com/golang/protobuf/protoc-gen-go/descriptor;descriptor" (and 1 more errors)
```

This is because `server.tmpl` just naively uses the package declaration as the import statement, which results in invalid like above. I fixed truncating the package declaration at the semicolon.

I also propose to automatically include common google apis as part of Proto Path as I find them very commonly used in services, so it would be a nice convenience feature.  