### PR TITLE
change renstrom/fuzzysearch to lithammer/fuzzysearch.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ RUN go get -u -v github.com/golang/protobuf/protoc-gen-go \
 	google.golang.org/grpc/reflection \
 	golang.org/x/net/context \
 	github.com/go-chi/chi \
-	github.com/renstrom/fuzzysearch/fuzzy \
+	github.com/lithammer/fuzzysearch/fuzzy \
 	golang.org/x/tools/imports
 
 RUN go get -u -v github.com/gobuffalo/packr/v2/... \

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -38,7 +38,7 @@
   version = "1.0.0"
 
 [[constraint]]
-  name = "github.com/renstrom/fuzzysearch"
+  name = "github.com/lithammer/fuzzysearch"
   version = "1.0.0"
 
 [[constraint]]

--- a/stub/storage.go
+++ b/stub/storage.go
@@ -9,7 +9,7 @@ import (
 	"regexp"
 	"sync"
 
-	"github.com/renstrom/fuzzysearch/fuzzy"
+	"github.com/lithammer/fuzzysearch/fuzzy"
 )
 
 var mx = sync.Mutex{}


### PR DESCRIPTION
Because the repo has been moved to lithammer.
It is also needed for `go mod` to work properly.

Testing:
- dep ensure -v
- go build
- docker build -t gripmock .