### PR TITLE
Run packr2 from $GOPATH

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,7 +34,7 @@ COPY . /go/src/github.com/tokopedia/gripmock
 
 WORKDIR /go/src/github.com/tokopedia/gripmock/protoc-gen-gripmock
 
-RUN packr2
+RUN cd $GOPATH && packr2
 
 # install generator plugin
 RUN go install -v


### PR DESCRIPTION
When running packr2 the current working directory needs
to be $GOPATH to succeed the modules resolution.