### PR TITLE
Support nested fields in input matching.

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -92,7 +92,11 @@ Stub will respond with the expected response only if the request matches any rul
 So if you do a `curl -X POST -d '{"service":"Greeter","method":"SayHello","data":{"name":"gripmock"}}' localhost:4771/find` stub service will find a match from listed stubs stored there.
 
 ### Input Matching Rule
-Input matching has 3 rules to match an input. which is **equals**,**contains** and **regex**
+Input matching has 3 rules to match an input: **equals**,**contains** and **regex**
+<br>
+Nested fields are allowed for input matching too for all JSON data types. (`string`, `bool`, `array`, etc.)
+<br>
+**Gripmock** recursively goes over the fields and tries to match with given input.
 <br>
 **equals** will match the exact field name and value of input into expected stub. example stub JSON:
 ```
@@ -101,7 +105,15 @@ Input matching has 3 rules to match an input. which is **equals**,**contains** a
   .
   "input":{
     "equals":{
-      "name":"gripmock"
+      "name":"gripmock",
+      "greetings": {
+            "english": "Hello World!",
+            "indonesian": "Halo Dunia!",
+            "turkish": "Merhaba Dünya!"
+      },
+      "ok": true,
+      "numbers": [4, 8, 15, 16, 23, 42]
+      "null": null
     }
   }
   .
@@ -116,7 +128,10 @@ Input matching has 3 rules to match an input. which is **equals**,**contains** a
   .
   "input":{
     "contains":{
-      "field2":"hello"
+      "field2":"hello",
+      "field4":{
+        "field5": "value5"
+      } 
     }
   }
   .
@@ -132,7 +147,8 @@ Input matching has 3 rules to match an input. which is **equals**,**contains** a
   .
   "input":{
     "matches":{
-      "name":"^grip.*$"
+      "name":"^grip.*$",
+      "cities": ["Jakarta", "Istanbul", ".*grad$"]
     }
   }
   .

--- a/gripmock.go
+++ b/gripmock.go
@@ -54,7 +54,7 @@ func main() {
 	protoPaths := flag.Args()
 
 	if len(protoPaths) == 0 {
-		log.Fatal("Need atleast one proto file")
+		log.Fatal("Need at least one proto file")
 	}
 
 	importDirs := strings.Split(*imports, ",")

--- a/stub/stub_test.go
+++ b/stub/stub_test.go
@@ -20,7 +20,7 @@ func TestStub(t *testing.T) {
 
 	cases := []test{
 		{
-			name: "add stub simple",
+			name: "add simple stub",
 			mock: func() *http.Request {
 				payload := `{
 						"service": "Testing",
@@ -54,6 +54,46 @@ func TestStub(t *testing.T) {
 			name: "find stub equals",
 			mock: func() *http.Request {
 				payload := `{"service":"Testing","method":"TestMethod","data":{"Hola":"Mundo"}}`
+				return httptest.NewRequest("POST", "/find", bytes.NewReader([]byte(payload)))
+			},
+			handler: handleFindStub,
+			expect:  "{\"data\":{\"Hello\":\"World\"},\"error\":\"\"}\n",
+		},
+		{
+			name: "add nested stub equals",
+			mock: func() *http.Request {
+				payload := `{
+						"service": "NestedTesting",
+						"method":"TestMethod",
+						"input":{
+							"equals":{
+										"name": "Afra Gokce",
+										"age": 1,
+										"girl": true,
+										"null": null,
+										"greetings": {
+											"hola": "mundo",
+											"merhaba": "dunya"
+										},
+										"cities": ["Istanbul", "Jakarta"]
+							}
+						},
+						"output":{
+							"data":{
+								"Hello":"World"
+							}
+						}
+					}`
+				read := bytes.NewReader([]byte(payload))
+				return httptest.NewRequest("POST", "/add", read)
+			},
+			handler: addStub,
+			expect:  `Success add stub`,
+		},
+		{
+			name: "find nested stub equals",
+			mock: func() *http.Request {
+				payload := `{"service":"NestedTesting","method":"TestMethod","data":{"name":"Afra Gokce","age":1,"girl":true,"null":null,"greetings":{"hola":"mundo","merhaba":"dunya"},"cities":["Istanbul","Jakarta"]}}`
 				return httptest.NewRequest("POST", "/find", bytes.NewReader([]byte(payload)))
 			},
 			handler: handleFindStub,
@@ -98,7 +138,57 @@ func TestStub(t *testing.T) {
 			},
 			handler: handleFindStub,
 			expect:  "{\"data\":{\"hello\":\"world\"},\"error\":\"\"}\n",
-		}, {
+		},
+		{
+			name: "add nested stub contains",
+			mock: func() *http.Request {
+				payload := `{
+								"service": "NestedTesting",
+								"method":"TestMethod",
+								"input":{
+									"contains":{
+												"key": "value",
+												"greetings": {
+													"hola": "mundo",
+													"merhaba": "dunya"
+												},
+												"cities": ["Istanbul", "Jakarta"]
+									}
+								},
+								"output":{
+									"data":{
+										"hello":"world"
+									}
+								}
+							}`
+				return httptest.NewRequest("POST", "/add", bytes.NewReader([]byte(payload)))
+			},
+			handler: addStub,
+			expect:  `Success add stub`,
+		},
+		{
+			name: "find nested stub contains",
+			mock: func() *http.Request {
+				payload := `{
+						"service":"NestedTesting",
+						"method":"TestMethod",
+						"data":{
+								"key": "value",
+								"anotherKey": "anotherValue",
+								"greetings": {
+									"hola": "mundo",
+									"merhaba": "dunya",
+									"hello": "world"
+								},
+								"cities": ["Istanbul", "Jakarta", "Winterfell"]
+						}
+					}`
+				return httptest.NewRequest("GET", "/find", bytes.NewReader([]byte(payload)))
+			},
+			handler: handleFindStub,
+			expect:  "{\"data\":{\"hello\":\"world\"},\"error\":\"\"}\n",
+		},
+		{
 			name: "add stub matches regex",
 			mock: func() *http.Request {
 				payload := `{
@@ -119,7 +209,8 @@ func TestStub(t *testing.T) {
 			},
 			handler: addStub,
 			expect:  "Success add stub",
-		}, {
+		},
+		{
 			name: "find stub matches regex",
 			mock: func() *http.Request {
 				payload := `{
@@ -133,7 +224,58 @@ func TestStub(t *testing.T) {
 			},
 			handler: handleFindStub,
 			expect:  "{\"data\":{\"reply\":\"OK\"},\"error\":\"\"}\n",
-		}, {
+		},
+		{
+			name: "add nested stub nested matches regex",
+			mock: func() *http.Request {
+				payload := `{
+						"service":"NestedTesting2",
+						"method":"TestMethod",
+						"input":{
+							"matches":{
+										"key": "[a-z]{3}ue",
+										"greetings": {
+											"hola": "mundo",
+											"merhaba": "dunya",
+											"hello": "^he[l]{2,}o$"
+										},
+										"cities": ["Istanbul", "Jakarta", ".*"]
+							}
+						},
+						"output":{
+							"data":{
+								"reply":"OK"
+							}
+						}
+					}`
+				return httptest.NewRequest("POST", "/add", bytes.NewReader([]byte(payload)))
+			},
+			handler: addStub,
+			expect:  "Success add stub",
+		},
+		{
+			name: "find nested stub matches regex",
+			mock: func() *http.Request {
+				payload := `{
+						"service":"NestedTesting2",
+						"method":"TestMethod",
+						"data":{
+								"key": "value",
+								"greetings": {
+									"hola": "mundo",
+									"merhaba": "dunya",
+									"hello": "helllllo"
+								},
+								"cities": ["Istanbul", "Jakarta", "Gotham"]
+							}
+						}
+					}`
+				return httptest.NewRequest("GET", "/find", bytes.NewReader([]byte(payload)))
+			},
+			handler: handleFindStub,
+			expect:  "{\"data\":{\"reply\":\"OK\"},\"error\":\"\"}\n",
+		},
+		{
 			name: "error find stub contains",
 			mock: func() *http.Request {
 				payload := `{
@@ -149,7 +291,8 @@ func TestStub(t *testing.T) {
 			},
 			handler: handleFindStub,
 			expect:  "Can't find stub \n\nService: Testing \n\nMethod: TestMethod \n\nInput\n\n{\n\tfield1: hello field1\n\tfield2: hello field2\n\tfield3: hello field4\n}\n\nClosest Match \n\ncontains:{\n\tfield1: hello field1\n\tfield3: hello field3\n}",
-		}, {
+		},
+		{
 			name: "error find stub equals",
 			mock: func() *http.Request {
 				payload := `{"service":"Testing","method":"TestMethod","data":{"Hola":"Dunia"}}`


### PR DESCRIPTION
Currently, Gripmock can match with only first-level fields of given JSON.

With this feature, it will be allowed to match in nested fields with supporting "equals", "contains" and "matches".

I've fixed some typos and added new test cases.