### PR TITLE
added feature for extra delay for grpc apis

### DIFF
--- a/stub/storage.go
+++ b/stub/storage.go
@@ -8,6 +8,7 @@ import (
 	"reflect"
 	"regexp"
 	"sync"
+	"time"
 
 	"github.com/lithammer/fuzzysearch/fuzzy"
 )
@@ -71,6 +72,7 @@ func findStub(stub *findStubPayload) (*Output, error) {
 		if expect := stubrange.Input.Equals; expect != nil {
 			closestMatch = append(closestMatch, closeMatch{"equals", expect})
 			if equals(stub.Data, expect) {
+				time.Sleep(time.Duration(stubrange.Output.Delay)*time.Millisecond)
 				return &stubrange.Output, nil
 			}
 		}
@@ -78,6 +80,7 @@ func findStub(stub *findStubPayload) (*Output, error) {
 		if expect := stubrange.Input.Contains; expect != nil {
 			closestMatch = append(closestMatch, closeMatch{"contains", expect})
 			if contains(stubrange.Input.Contains, stub.Data) {
+				time.Sleep(time.Duration(stubrange.Output.Delay)*time.Millisecond)
 				return &stubrange.Output, nil
 			}
 		}
@@ -85,6 +88,7 @@ func findStub(stub *findStubPayload) (*Output, error) {
 		if expect := stubrange.Input.Matches; expect != nil {
 			closestMatch = append(closestMatch, closeMatch{"matches", expect})
 			if matches(stubrange.Input.Matches, stub.Data) {
+				time.Sleep(time.Duration(stubrange.Output.Delay)*time.Millisecond)
 				return &stubrange.Output, nil
 			}
 		}

--- a/stub/stub.go
+++ b/stub/stub.go
@@ -60,6 +60,7 @@ type Input struct {
 }
 
 type Output struct {
+	Delay int                    `json:"delay"`
 	Data  map[string]interface{} `json:"data"`
 	Error string                 `json:"error"`
 }

--- a/stub/stub_test.go
+++ b/stub/stub_test.go
@@ -48,7 +48,7 @@ func TestStub(t *testing.T) {
 				return httptest.NewRequest("GET", "/", nil)
 			},
 			handler: listStub,
-			expect:  "{\"Testing\":{\"TestMethod\":[{\"Input\":{\"equals\":{\"Hola\":\"Mundo\"},\"contains\":null,\"matches\":null},\"Output\":{\"data\":{\"Hello\":\"World\"},\"error\":\"\"}}]}}\n",
+			expect:  "{\"Testing\":{\"TestMethod\":[{\"Input\":{\"equals\":{\"Hola\":\"Mundo\"},\"contains\":null,\"matches\":null},\"Output\":{\"delay\":0,\"data\":{\"Hello\":\"World\"},\"error\":\"\"}}]}}\n",
 		},
 		{
 			name: "find stub equals",
@@ -57,7 +57,7 @@ func TestStub(t *testing.T) {
 				return httptest.NewRequest("POST", "/find", bytes.NewReader([]byte(payload)))
 			},
 			handler: handleFindStub,
-			expect:  "{\"data\":{\"Hello\":\"World\"},\"error\":\"\"}\n",
+			expect:  "{\"delay\":0,\"data\":{\"Hello\":\"World\"},\"error\":\"\"}\n",
 		},
 		{
 			name: "add stub contains",
@@ -97,7 +97,7 @@ func TestStub(t *testing.T) {
 				return httptest.NewRequest("GET", "/find", bytes.NewReader([]byte(payload)))
 			},
 			handler: handleFindStub,
-			expect:  "{\"data\":{\"hello\":\"world\"},\"error\":\"\"}\n",
+			expect:  "{\"delay\":0,\"data\":{\"hello\":\"world\"},\"error\":\"\"}\n",
 		}, {
 			name: "add stub matches regex",
 			mock: func() *http.Request {
@@ -132,7 +132,7 @@ func TestStub(t *testing.T) {
 				return httptest.NewRequest("GET", "/find", bytes.NewReader([]byte(payload)))
 			},
 			handler: handleFindStub,
-			expect:  "{\"data\":{\"reply\":\"OK\"},\"error\":\"\"}\n",
+			expect:  "{\"delay\":0,\"data\":{\"reply\":\"OK\"},\"error\":\"\"}\n",
 		}, {
 			name: "error find stub contains",
 			mock: func() *http.Request {


### PR DESCRIPTION
In our use of gripmock we came across a need of extra delay over grpc response. Added code for extraa delay for grpc apis, which can help library users to configure any delay in their api response.