### PR TITLE
add `--stub-watch` option

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -77,6 +77,8 @@ mount your stub file in `/mystubs` folder then mount it to docker like
  `docker run -p 4770:4770 -p 4771:4771 -v /mypath:/proto -v /mystubs:/stub tkpd/gripmock --stub=/stub /proto/hello.proto`
  
 Please note that Gripmock still serves http stubbing to modify stored stubs on the fly.
+
+You may pass `--stub-watch` option to watch changes in the stub directory. When you edit a file in the directory, it will clean the stubs and load all files in the directory again to make your changes available.
  
 ## <a name="input_matching"></a>Input Matching
 Stub will respond with the expected response only if the request matches any rule. Stub service will serve `/find` endpoint with format:

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/tokopedia/gripmock
 go 1.15
 
 require (
+	github.com/fsnotify/fsnotify v1.4.9
 	github.com/go-chi/chi v4.1.2+incompatible
 	github.com/gobuffalo/here v0.6.2 // indirect
 	github.com/golang/protobuf v1.4.3

--- a/gripmock.go
+++ b/gripmock.go
@@ -20,6 +20,7 @@ func main() {
 	adminport := flag.String("admin-port", "4771", "Port of stub admin server")
 	adminBindAddr := flag.String("admin-listen", "", "Adress the admin server will bind to. Default to localhost, set to 0.0.0.0 to use from another machine")
 	stubPath := flag.String("stub", "", "Path where the stub files are (Optional)")
+	stubWatch := flag.Bool("stub-watch", false, "watch the stub directory for change")
 	imports := flag.String("imports", "/protobuf", "comma separated imports path. default path /protobuf is where gripmock Dockerfile install WKT protos")
 	// for backwards compatibility
 	if os.Args[1] == "gripmock" {
@@ -45,9 +46,10 @@ func main() {
 
 	// run admin stub server
 	stub.RunStubServer(stub.Options{
-		StubPath: *stubPath,
-		Port:     *adminport,
-		BindAddr: *adminBindAddr,
+		StubPath:  *stubPath,
+		StubWatch: *stubWatch,
+		Port:      *adminport,
+		BindAddr:  *adminBindAddr,
 	})
 
 	// parse proto files

--- a/stub/stub.go
+++ b/stub/stub.go
@@ -7,14 +7,15 @@ import (
 	"log"
 	"net/http"
 	"strings"
-	
+
 	"github.com/go-chi/chi"
 )
 
 type Options struct {
-	Port     string
-	BindAddr string
-	StubPath string
+	Port      string
+	BindAddr  string
+	StubPath  string
+	StubWatch bool
 }
 
 const DEFAULT_PORT = "4771"
@@ -32,6 +33,13 @@ func RunStubServer(opt Options) {
 
 	if opt.StubPath != "" {
 		readStubFromFile(opt.StubPath)
+
+		if opt.StubWatch {
+			fmt.Println("Watching for changes in " + opt.StubPath)
+			go func() {
+				watchStubDir(opt.StubPath)
+			}()
+		}
 	}
 
 	fmt.Println("Serving stub admin on http://" + addr)


### PR DESCRIPTION
## Overview

First of all, thank you for maintaining such a great project!

This PR adds `--stub-watch` option to gripmock. With this option enabled, the program watch for changes in the stub directory, and when you make changes in the directory, it will 1) clear all registered stubs (just as calling `/clear`) and 2) register stubs in the directory.

## Motivation

I store all stubs in the directory and load them via `--stub` option. While this works okay, I need to restart the program every time I edit the stub files, and I thought it would be nice if the program can detect changes and automatically use the latest version. 

This is especially useful when we're debugging clients using gripmock as a server.

## Discussion

- I decided to clear stubs on change because there is no trivial way to replace a specific stub. This might be problematic if you use both `--stub-watch` and `POST /add` at the same time, as stubs added by HTTP API will be deleted.
  - I think you usually want to use one, not both.
  - We might add a field in `stub` indicating which file it came from to solve this problem.
- I'm not sure if there's a need for this feature. I'm hoping this to be a PoC for people who are using gripmock in a similar way to me even if it doesn't get merged to the mainstream.
- I'm new to Golang. My apologies if there is any rudimentary error.