### PR TITLE
Fix "matches" handling of non-string types

### DIFF
--- a/stub/storage.go
+++ b/stub/storage.go
@@ -167,11 +167,18 @@ func deepEqual(expect, actual interface{}) bool {
 }
 
 func regexMatch(expect, actual interface{}) bool {
-	match, err := regexp.Match(expect.(string), []byte(actual.(string)))
-	if err != nil {
-		log.Printf("Error on matching regex %s with %s error:%v\n", expect, actual, err)
+	var expectedStr, expectedStringOk = expect.(string)
+	var actualStr, actualStringOk = actual.(string)
+
+	if expectedStringOk && actualStringOk {
+		match, err := regexp.Match(expectedStr, []byte(actualStr))
+		if err != nil {
+			log.Printf("Error on matching regex %s with %s error:%v\n", expect, actual, err)
+		}
+		return match
 	}
-	return match
+
+	return deepEqual(expect, actual)
 }
 
 func equals(expect, actual map[string]interface{}) bool {

--- a/stub/stub_test.go
+++ b/stub/stub_test.go
@@ -226,7 +226,7 @@ func TestStub(t *testing.T) {
 			expect:  "{\"data\":{\"reply\":\"OK\"},\"error\":\"\"}\n",
 		},
 		{
-			name: "add nested stub nested matches regex",
+			name: "add nested stub matches regex",
 			mock: func() *http.Request {
 				payload := `{
 						"service":"NestedTesting2",
@@ -235,11 +235,12 @@ func TestStub(t *testing.T) {
 							"matches":{
 										"key": "[a-z]{3}ue",
 										"greetings": {
-											"hola": "mundo",
-											"merhaba": "dunya",
+											"hola": 1,
+											"merhaba": true,
 											"hello": "^he[l]{2,}o$"
 										},
-										"cities": ["Istanbul", "Jakarta", ".*"]
+										"cities": ["Istanbul", "Jakarta", ".*"],
+										"mixed": [5.5, false, ".*"]
 							}
 						},
 						"output":{
@@ -262,11 +263,12 @@ func TestStub(t *testing.T) {
 						"data":{
 								"key": "value",
 								"greetings": {
-									"hola": "mundo",
-									"merhaba": "dunya",
+									"hola": 1,
+									"merhaba": true,
 									"hello": "helllllo"
 								},
-								"cities": ["Istanbul", "Jakarta", "Gotham"]
+								"cities": ["Istanbul", "Jakarta", "Gotham"],
+								"mixed": [5.5, false, "Gotham"]
 							}
 						}
 					}`


### PR DESCRIPTION
This should fix handling of non-string fields when using `matches`. See amended test for example. Before the fix `matches` would fail on non-string fields with the following error:
```
=== RUN   TestStub/find_nested_stub_matches_regex_map
    --- FAIL: TestStub/find_nested_stub_matches_regex_map (0.00s)
panic: interface conversion: interface {} is float64, not string [recovered]
	panic: interface conversion: interface {} is float64, not string

goroutine 34 [running]:
testing.tRunner.func1.2({0x11cb960, 0xc00013ddd0})
	/usr/local/Cellar/go/1.17/libexec/src/testing/testing.go:1209 +0x24e
testing.tRunner.func1()
	/usr/local/Cellar/go/1.17/libexec/src/testing/testing.go:1212 +0x218
panic({0x11cb960, 0xc00013ddd0})
	/usr/local/Cellar/go/1.17/libexec/src/runtime/panic.go:1038 +0x215
github.com/tokopedia/gripmock/stub.regexMatch({0x11bdb60, 0xc0000a7a80}, {0x11bdb60, 0xc0000a7b58})
	/Users/wigbam/workspace/intellij/opensource/gripmock/stub/storage.go:174 +0x167
github.com/tokopedia/gripmock/stub.find({0x11bdb60, 0xc0000a7a80}, {0x11bdb60, 0xc0000a7b58}, 0x68, 0x0, 0x12105e0)
	/Users/wigbam/workspace/intellij/opensource/gripmock/stub/storage.go:261 +0x1de
github.com/tokopedia/gripmock/stub.find({0x11c96c0, 0xc00013da10}, {0x11c96c0, 0xc00013dce0}, 0x1, 0x0, 0x12105e0)
	/Users/wigbam/workspace/intellij/opensource/gripmock/stub/storage.go:255 +0x265
github.com/tokopedia/gripmock/stub.find({0x11c96c0, 0xc00013d9e0}, {0x11c96c0, 0xc00013dcb0}, 0x1, 0x0, 0x12105e0)
	/Users/wigbam/workspace/intellij/opensource/gripmock/stub/storage.go:255 +0x265
github.com/tokopedia/gripmock/stub.find({0x11c96c0, 0xc00013d9b0}, {0x11c96c0, 0xc00013dc80}, 0x1, 0x0, 0x12105e0)
	/Users/wigbam/workspace/intellij/opensource/gripmock/stub/storage.go:255 +0x265
github.com/tokopedia/gripmock/stub.matches(...)
	/Users/wigbam/workspace/intellij/opensource/gripmock/stub/storage.go:193
github.com/tokopedia/gripmock/stub.findStub(0xc00013dc20)
	/Users/wigbam/workspace/intellij/opensource/gripmock/stub/storage.go:89 +0x813
github.com/tokopedia/gripmock/stub.handleFindStub({0x1245050, 0xc0000ed200}, 0xc000128e00)
	/Users/wigbam/workspace/intellij/opensource/gripmock/stub/stub.go:151 +0x10e
github.com/tokopedia/gripmock/stub.TestStub.func18(0x0)
	/Users/wigbam/workspace/intellij/opensource/gripmock/stub/stub_test.go:358 +0xdb
testing.tRunner(0xc000164000, 0xc00014a9a0)
	/usr/local/Cellar/go/1.17/libexec/src/testing/testing.go:1259 +0x102
created by testing.(*T).Run
	/usr/local/Cellar/go/1.17/libexec/src/testing/testing.go:1306 +0x35a
```

## This is my first ever attempt at Golang, so amend as you see fit 😄 