### PR TITLE
fix exmaple/simple client not working as readme.md instruction

### DIFF
--- a/example/simple/client/main.go
+++ b/example/simple/client/main.go
@@ -25,7 +25,7 @@ func main() {
 	c := pb.NewGripmockClient(conn)
 
 	// Contact the server and print out its response.
-	name := "tokopedia"
+	name := "gripmock"
 	if len(os.Args) > 1 {
 		name = os.Args[1]
 	}


### PR DESCRIPTION
while following example instruction on readme.md, I found that client.go requests name with "tokopedia" whereas readme.md add service stub as "gripmock" (sha: d43af75)

this PR fixes example/simple/client/main.go to make client do a grpc request with name "gripmock"