### PR TITLE
fix exmaple/simple client not working as readme.md instruction

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -23,7 +23,7 @@ basic syntax to run GripMock is
 - Install [Docker](https://docs.docker.com/install/)
 - Run `docker pull tkpd/gripmock` to pull the image
 - We are gonna mount `/mypath/hello.proto` (it must be a fullpath) into a container and also we expose ports needed. Run `docker run -p 4770:4770 -p 4771:4771 -v /mypath:/proto tkpd/gripmock /proto/hello.proto`
-- On a separate terminal we are gonna add a stub into the stub service. Run `curl -X POST -d '{"service":"Greeter","method":"SayHello","input":{"equals":{"name":"gripmock"}},"output":{"data":{"message":"Hello GripMock"}}}' localhost:4771/add `
+- On a separate terminal we are gonna add a stub into the stub service. Run `curl -X POST -d '{"service":"Gripmock","method":"SayHello","input":{"equals":{"name":"gripmock"}},"output":{"data":{"message":"Hello GripMock"}}}' localhost:4771/add `
 - Now we are ready to test it with our client. You can find a client example file under `example/simple/client/`. Execute one of your preferred language. Example for go: `go run example/simple/client/go/*.go`
 
 Check [`example`](https://github.com/tokopedia/gripmock/tree/master/example) folder for various usecase of gripmock.

--- a/example/simple/client/main.go
+++ b/example/simple/client/main.go
@@ -25,7 +25,7 @@ func main() {
 	c := pb.NewGripmockClient(conn)
 
 	// Contact the server and print out its response.
-	name := "tokopedia"
+	name := "gripmock"
 	if len(os.Args) > 1 {
 		name = os.Args[1]
 	}


### PR DESCRIPTION
## how to reproduce

read quick usage
https://github.com/tokopedia/gripmock/tree/d43af75ebe00d66c991d6ef5779f263b8cfb84ed#quick-usage

## description
while following example instruction on readme.md, I found that client.go doesn't match with instruction environment (sha: https://github.com/tokopedia/gripmock/commit/d43af75ebe00d66c991d6ef5779f263b8cfb84ed)

readme registers service `Greeter`, method `SayHello`, input `{ name: "gripmock" }`
example/client/main.go uses service `Gripmock`, method `SayHello`, input `{ name: "tokopedia" }`

this PR fixes readme.md and main.go to fix those mismatching.