### PR TITLE
Added scripts for multi platform support

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -7,4 +7,4 @@ fi
 
 go build ../.
 
-docker buildx build --load -t "tkpd/gripmock:$1" --platform linux/arm64 .
+docker buildx build --load -t "tkpd/gripmock:$1" --platform linux/amd64 .

--- a/push.sh
+++ b/push.sh
@@ -7,4 +7,4 @@ fi
 
 go build ../.
 
-docker buildx build --load -t "tkpd/gripmock:$1" --platform linux/arm64 .
+docker buildx build --push -t "tkpd/gripmock:$1" --platform linux/amd64,linux/arm64 .


### PR DESCRIPTION
Solves #124 

@jekiapp I modified the `build.sh` scripts so you can build locally the image targeting the usual `amd/64`, but when you want to push a release you can execute `push.sh` instead to push the same image, with the same version, on both `amd/64` and `arm/64`.

I tried it on my docker account, and this is how it looks:
https://hub.docker.com/repository/registry-1.docker.io/pmorelli92/gripmock/tags?page=1&ordering=last_updated

Could you be kind enough to do us a favor an push the current release to be multi platform?