### PR TITLE
fix: bug multi package

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -26,7 +26,7 @@ basic syntax to run GripMock is
 - Run `docker pull tkpd/gripmock` to pull the image
 - We are gonna mount `/mypath/hello.proto` (it must be a fullpath) into a container and also we expose ports needed. Run `docker run -p 4770:4770 -p 4771:4771 -v /mypath:/proto tkpd/gripmock /proto/hello.proto`
 - On a separate terminal we are gonna add a stub into the stub service. Run `curl -X POST -d '{"service":"Gripmock","method":"SayHello","input":{"equals":{"name":"gripmock"}},"output":{"data":{"message":"Hello GripMock"}}}' localhost:4771/add `
-- Now we are ready to test it with our client. You can find a client example file under `example/simple/client/`. Execute one of your preferred language. Example for go: `go run example/simple/client/go/*.go`
+- Now we are ready to test it with our client. You can find a client example file under `example/simple/client/`. Execute one of your preferred language. Example for go: `go run example/simple/client/*.go`
 
 Check [`example`](https://github.com/tokopedia/gripmock/tree/master/example) folder for various usecase of gripmock.
 

--- a/example/multi-package/entrypoint.sh
+++ b/example/multi-package/entrypoint.sh
@@ -3,10 +3,10 @@
 # this file is used by .github/workflows/integration-test.yml
 
 # we need to add example/multi-package ar as included import path
-# without it protoc could not find the bar/bar.proto
+# without it protoc could not find the foo.proto & hello.proto
 gripmock --stub=example/multi-package/stub --imports=example/multi-package/ \
-  example/multi-package/foo.proto example/multi-package/hello.proto \
-  example/multi-package/bar/bar.proto &
+  example/multi-package/bar/bar.proto \
+  example/multi-package/foo.proto example/multi-package/hello.proto &
 
 # wait for generated files to be available and gripmock is up
 sleep 2

--- a/gripmock_test.go
+++ b/gripmock_test.go
@@ -1,0 +1,59 @@
+package main
+
+import (
+	"reflect"
+	"testing"
+)
+
+func Test_getProtodirs(t *testing.T) {
+	type args struct {
+		protoPath string
+		imports   []string
+	}
+	tests := []struct {
+		name string
+		args args
+		want []string
+	}{
+		{
+			name: "deduced",
+			args: args{
+				protoPath: "protogen/example/multi-package/hello.proto",
+				imports:   []string{"/protobuf"},
+			},
+			want: []string{
+				"protogen/example/multi-package",
+				"/protobuf",
+			},
+		},
+		{
+			name: "specified in imports",
+			args: args{
+				protoPath: "protogen/example/multi-package/hello.proto",
+				imports:   []string{"/protobuf", "/example/multi-package/"},
+			},
+			want: []string{
+				"protogen/example/multi-package",
+				"/protobuf",
+			},
+		},
+		{
+			name: "specified in imports 2",
+			args: args{
+				protoPath: "protogen/example/multi-package/bar/bar.proto",
+				imports:   []string{"example/multi-package", "/protobuf"},
+			},
+			want: []string{
+				"protogen/example/multi-package",
+				"/protobuf",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := getProtodirs(tt.args.protoPath, tt.args.imports); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("getProtodirs() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
### Motivation
protodir is deduced from first protopath. it doesn't work if the proto files are in multiple packages.
we can specify the correct protodir in `imports` param, but there will be 2 protodir with same content.
this PR fix the issue by replacing the deduced protodir with its prefix (if specified in `imports` param)

### Changes
- detect prefix in `imports`
- add unit test
- edit integration test to the problematic case
