### PR TITLE
feat: add new endpoint to verify number of calls for stub

### DIFF
--- a/stub/stub.go
+++ b/stub/stub.go
@@ -7,7 +7,7 @@ import (
 	"log"
 	"net/http"
 	"strings"
-	
+
 	"github.com/go-chi/chi"
 )
 
@@ -29,6 +29,7 @@ func RunStubServer(opt Options) {
 	r.Get("/", listStub)
 	r.Post("/find", handleFindStub)
 	r.Get("/clear", handleClearStub)
+	r.Get("/verify", handleVerifyStubCalled)
 
 	if opt.StubPath != "" {
 		readStubFromFile(opt.StubPath)
@@ -106,7 +107,7 @@ func validateStub(stub *Stub) error {
 	if stub.Method == "" {
 		return fmt.Errorf("Method name can't be emtpy")
 	}
-	
+
 	// due to golang implementation
 	// method name must capital
 	stub.Method = strings.Title(stub.Method)
@@ -143,11 +144,11 @@ func handleFindStub(w http.ResponseWriter, r *http.Request) {
 		responseError(err, w)
 		return
 	}
-	
+
 	// due to golang implementation
 	// method name must capital
 	stub.Method = strings.Title(stub.Method)
-	
+
 	output, err := findStub(stub)
 	if err != nil {
 		log.Println(err)
@@ -162,4 +163,28 @@ func handleFindStub(w http.ResponseWriter, r *http.Request) {
 func handleClearStub(w http.ResponseWriter, r *http.Request) {
 	clearStorage()
 	w.Write([]byte("OK"))
+}
+
+type verifyStubCallPayload struct {
+	Service string `json:"service"`
+	Method  string `json:"method"`
+}
+
+func handleVerifyStubCalled(w http.ResponseWriter, r *http.Request) {
+	verifyPayload := new(verifyStubCallPayload)
+	err := json.NewDecoder(r.Body).Decode(verifyPayload)
+	if err != nil {
+		responseError(err, w)
+		return
+	}
+
+	output, err := getStubTimesCalled(verifyPayload)
+	if err != nil {
+		log.Println(err)
+		responseError(err, w)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(output)
 }

--- a/stub/stub_test.go
+++ b/stub/stub_test.go
@@ -301,6 +301,15 @@ func TestStub(t *testing.T) {
 			handler: handleFindStub,
 			expect:  "Can't find stub \n\nService: Testing \n\nMethod: TestMethod \n\nInput\n\n{\n\tHola: Dunia\n}\n\nClosest Match \n\nequals:{\n\tHola: Mundo\n}",
 		},
+		{
+			name: "verify stub times called",
+			mock: func() *http.Request {
+				payload := `{"service":"Testing2","method":"TestMethod"}`
+				return httptest.NewRequest("GET", "/verify", bytes.NewReader([]byte(payload)))
+			},
+			handler: handleVerifyStubCalled,
+			expect:  "{\"data\":{\"timesCalled\":1},\"error\":\"\"}\n",
+		},
 	}
 
 	for _, v := range cases {


### PR DESCRIPTION
## Motivation

As also suggested in https://github.com/tokopedia/gripmock/issues/66, I think it would be useful for some test scenarios to verify if a stub was consumed or not. 

## Discussion

- I was not sure about just exposing the new `timesCalled` json prop for the storage type or alike, so that the `listStub` API already provides that info for the clients; instead of adding a new HTTP API endpoint.

- I'm new to Golang, sorry for any rudimentary errors 🙈