### PR TITLE
feat: support external dep with local proto

### DIFF
--- a/fix_gopackage.sh
+++ b/fix_gopackage.sh
@@ -29,6 +29,10 @@ do
   mkdir -p "$newdir" && \
     cp "$proto" "$_" && \
 
+  existingGoPackage=$(grep -n '^option go_package.*$' "$newfile")
+
+  if [[ "$existingGoPackage" != *"// external"* ]]; then 
+  
     # Force remove any declaration of go_package
     # then replace it with our own declaration below
     sed -i 's/^option go_package.*$//g' $newfile
@@ -41,6 +45,9 @@ do
 
   # append our own go_package delcaration just below "syntax" declaration
   sed -i "${syntaxLineNum}s~$~\n$goPackageString~" $newfile
+
+  fi;
+
   echo $newfile
 done
 


### PR DESCRIPTION
### Motivation

some people use external dependency like `github.com/gogo/googleapis/google/rpc`
and store copy of proto file in the proto dir.

in this case, we should not replace the go_package because it creates a namespace conflict.

### Changes

- do not replace go_package if the line contains comment `// external`
- output server.go to internal dir (for pulling dependency)
- copy server.go to intended destination
- `go mod tidy` before go run