### PR TITLE
Big numbers patch

### DIFF
--- a/protoc-gen-gripmock/server.tmpl
+++ b/protoc-gen-gripmock/server.tmpl
@@ -169,7 +169,9 @@ func findStub(service, method string, in, out protoiface.MessageV1) error {
 	}
 
 	respRPC := new(response)
-	err = json.NewDecoder(resp.Body).Decode(respRPC)
+	decoder := json.NewDecoder(resp.Body)
+	decoder.UseNumber()
+	err = decoder.Decode(respRPC)
 	if err != nil {
 		return fmt.Errorf("decoding json response %v",err)
 	}

--- a/stub/storage.go
+++ b/stub/storage.go
@@ -1,6 +1,7 @@
 package stub
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
@@ -297,8 +298,10 @@ func (sm *stubMapping) readStubFromFile(path string) {
 
 		if byt[0] == '[' && byt[len(byt)-1] == ']' {
 			var stubs []*Stub
-			err = json.Unmarshal(byt, &stubs)
-			if err != nil {
+			decoder := json.NewDecoder(bytes.NewReader(byt))
+			decoder.UseNumber()
+
+			if err = decoder.Decode(&stubs); err != nil {
 				log.Printf("Error when unmarshalling file %s. %v. skipping...", file.Name(), err)
 				continue
 			}
@@ -309,8 +312,10 @@ func (sm *stubMapping) readStubFromFile(path string) {
 		}
 
 		stub := new(Stub)
-		err = json.Unmarshal(byt, stub)
-		if err != nil {
+		decoder := json.NewDecoder(bytes.NewReader(byt))
+		decoder.UseNumber()
+
+		if err = decoder.Decode(stub); err != nil {
 			log.Printf("Error when unmarshalling file %s. %v. skipping...", file.Name(), err)
 			continue
 		}

--- a/stub/stub.go
+++ b/stub/stub.go
@@ -7,7 +7,7 @@ import (
 	"log"
 	"net/http"
 	"strings"
-	
+
 	"github.com/go-chi/chi"
 )
 
@@ -106,7 +106,7 @@ func validateStub(stub *Stub) error {
 	if stub.Method == "" {
 		return fmt.Errorf("Method name can't be emtpy")
 	}
-	
+
 	// due to golang implementation
 	// method name must capital
 	stub.Method = strings.Title(stub.Method)
@@ -138,16 +138,18 @@ type findStubPayload struct {
 
 func handleFindStub(w http.ResponseWriter, r *http.Request) {
 	stub := new(findStubPayload)
-	err := json.NewDecoder(r.Body).Decode(stub)
+	decoder := json.NewDecoder(r.Body)
+	decoder.UseNumber()
+	err := decoder.Decode(stub)
 	if err != nil {
 		responseError(err, w)
 		return
 	}
-	
+
 	// due to golang implementation
 	// method name must capital
 	stub.Method = strings.Title(stub.Method)
-	
+
 	output, err := findStub(stub)
 	if err != nil {
 		log.Println(err)


### PR DESCRIPTION
I have a similar issue: https://github.com/tokopedia/gripmock/issues/67

This fix fixes the problem with uint64/int64

---

If someone needs a fix, then you can temporarily use the docker image:
```sh
docker pull bavix/gripmock:1.13.0

or

docker pull ghcr.io/bavix/gripmock:1.13.0
```
https://hub.docker.com/r/bavix/gripmock

---

![jpeg-optimizer_black](https://github.com/tokopedia/gripmock/assets/5111255/154af108-f8e2-489f-bbfe-66460ddc5da7)

This MR is no longer relevant for me. I am developing it myself.

https://github.com/bavix/gripmock

docs: https://bavix.github.io/gripmock/#/
