### PR TITLE
New input matching rule: equals_unordered

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -151,6 +151,31 @@ Nested fields are allowed for input matching too for all JSON data types. (`stri
 }
 ```
 
+**equals_unordered** will match the exact field name and value of input into expected stub, except lists (wich are compared as sets). example stub JSON:
+
+
+```
+{
+  .
+  .
+  "input":{
+    "equals_unordered":{
+      "name":"gripmock",
+      "greetings": {
+            "english": "Hello World!",
+            "indonesian": "Halo Dunia!",
+            "turkish": "Merhaba Dünya!"
+      },
+      "ok": true,
+      "numbers": [4, 8, 15, 16, 23, 42]
+      "null": null
+    }
+  }
+  .
+  .
+}
+```
+
 **contains** will match input that has the value declared expected fields. example stub JSON:
 ```
 {

--- a/Readme.md
+++ b/Readme.md
@@ -122,7 +122,7 @@ Stub will respond with the expected response only if the request matches any rul
 So if you do a `curl -X POST -d '{"service":"Greeter","method":"SayHello","data":{"name":"gripmock"}}' localhost:4771/find` stub service will find a match from listed stubs stored there.
 
 ### Input Matching Rule
-Input matching has 3 rules to match an input: **equals**,**contains** and **regex**
+Input matching has 4 rules to match an input: **equals**, **equals_unordered**, **contains** and **regex**
 <br>
 Nested fields are allowed for input matching too for all JSON data types. (`string`, `bool`, `array`, etc.)
 <br>
@@ -151,7 +151,7 @@ Nested fields are allowed for input matching too for all JSON data types. (`stri
 }
 ```
 
-**equals_unordered** will match the exact field name and value of input into expected stub, except lists (wich are compared as sets). example stub JSON:
+**equals_unordered** will match the exact field name and value of input into expected stub, except lists (which are compared as sets). example stub JSON:
 
 
 ```

--- a/stub/stub.go
+++ b/stub/stub.go
@@ -55,10 +55,10 @@ type Stub struct {
 }
 
 type Input struct {
-	Equals   map[string]interface{} `json:"equals"`
-	EqualsSets   map[string]interface{} `json:"equals_sets"`
-	Contains map[string]interface{} `json:"contains"`
-	Matches  map[string]interface{} `json:"matches"`
+	Equals          map[string]interface{} `json:"equals"`
+	EqualsUnordered map[string]interface{} `json:"equals_unordered"`
+	Contains        map[string]interface{} `json:"contains"`
+	Matches         map[string]interface{} `json:"matches"`
 }
 
 type Output struct {
@@ -119,7 +119,7 @@ func validateStub(stub *Stub) error {
 		break
 	case stub.Input.Equals != nil:
 		break
-	case stub.Input.EqualsSets != nil:
+	case stub.Input.EqualsUnordered != nil:
 		break
 	case stub.Input.Matches != nil:
 		break

--- a/stub/stub.go
+++ b/stub/stub.go
@@ -56,6 +56,7 @@ type Stub struct {
 
 type Input struct {
 	Equals   map[string]interface{} `json:"equals"`
+	EqualsSets   map[string]interface{} `json:"equals_sets"`
 	Contains map[string]interface{} `json:"contains"`
 	Matches  map[string]interface{} `json:"matches"`
 }
@@ -117,6 +118,8 @@ func validateStub(stub *Stub) error {
 	case stub.Input.Contains != nil:
 		break
 	case stub.Input.Equals != nil:
+		break
+	case stub.Input.EqualsSets != nil:
 		break
 	case stub.Input.Matches != nil:
 		break

--- a/stub/stub_test.go
+++ b/stub/stub_test.go
@@ -48,7 +48,7 @@ func TestStub(t *testing.T) {
 				return httptest.NewRequest("GET", "/", nil)
 			},
 			handler: listStub,
-			expect:  "{\"Testing\":{\"TestMethod\":[{\"Input\":{\"equals\":{\"Hola\":\"Mundo\"},\"contains\":null,\"matches\":null},\"Output\":{\"data\":{\"Hello\":\"World\"},\"error\":\"\"}}]}}\n",
+			expect:  "{\"Testing\":{\"TestMethod\":[{\"Input\":{\"equals\":{\"Hola\":\"Mundo\"},\"equals_unordered\":null,\"contains\":null,\"matches\":null},\"Output\":{\"data\":{\"Hello\":\"World\"},\"error\":\"\"}}]}}\n",
 		},
 		{
 			name: "find stub equals",
@@ -98,6 +98,58 @@ func TestStub(t *testing.T) {
 			},
 			handler: handleFindStub,
 			expect:  "{\"data\":{\"Hello\":\"World\"},\"error\":\"\"}\n",
+		},
+		{
+			name: "add stub equals_unordered",
+			mock: func() *http.Request {
+				payload := `{
+								"service": "TestingUnordered",
+								"method":"TestMethod",
+								"input": {
+									"equals_unordered": {
+										"ids": [1,2]
+									}
+								},
+								"output":{
+									"data":{
+										"hello":"world"
+									}
+								}
+							}`
+				return httptest.NewRequest("POST", "/add", bytes.NewReader([]byte(payload)))
+			},
+			handler: addStub,
+			expect:  `Success add stub`,
+		},
+		{
+			name: "find stub equals_unordered",
+			mock: func() *http.Request {
+				payload := `{
+						"service":"TestingUnordered",
+						"method":"TestMethod",
+						"data":{
+							"ids":[1,2]
+						}
+					}`
+				return httptest.NewRequest("GET", "/find", bytes.NewReader([]byte(payload)))
+			},
+			handler: handleFindStub,
+			expect:  "{\"data\":{\"hello\":\"world\"},\"error\":\"\"}\n",
+		},
+		{
+			name: "find stub equals_unordered reversed",
+			mock: func() *http.Request {
+				payload := `{
+						"service":"TestingUnordered",
+						"method":"TestMethod",
+						"data":{
+							"ids":[2,1]
+						}
+					}`
+				return httptest.NewRequest("GET", "/find", bytes.NewReader([]byte(payload)))
+			},
+			handler: handleFindStub,
+			expect:  "{\"data\":{\"hello\":\"world\"},\"error\":\"\"}\n",
 		},
 		{
 			name: "add stub contains",


### PR DESCRIPTION
Added new inut matching rule equals_unordered, allowing find stubs for lists with different order

For example stub

```
{
  .
  .
  "input":{
    "equals_unordered":{
      "ids": [1, 2]
    }
  }
  .
  .
}
```
will match requests with ids=[1, 2] and ids=[2, 1]

when stub

```
{
  .
  .
  "input":{
    "equals":{
      "ids": [1, 2]
    }
  }
  .
  .
}
```
will match only requests with ids=[1, 2]
